### PR TITLE
use 'editor tabulation' instead of 4 spaces

### DIFF
--- a/snippets/javascript.json
+++ b/snippets/javascript.json
@@ -3,7 +3,7 @@
         "prefix": "promisef",
         "body": [
             "new Promise(function (resolve, reject) {",
-            "    $1",
+            "\t$1",
             "});"
         ],
         "description": "Promise with function"
@@ -12,7 +12,7 @@
         "prefix": "promise",
         "body": [
             "new Promise((resolve, reject) => {",
-            "    $1",
+            "\t$1",
             "});"
         ],
         "description": "Promise"

--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -3,7 +3,7 @@
         "prefix": "promise",
         "body": [
             "new Promise((resolve, reject) => {",
-            "    $1",
+            "\t$1",
             "});"
         ],
         "description": "Promise"


### PR DESCRIPTION
vscode will use the current tab size specified on settings